### PR TITLE
Include binding.gyp in the release tarballs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
 		"package.json",
 		"README.md",
 		"binding-options.js",
-		"prebuilds"
+		"prebuilds",
+		"binding.gyp",
+		"src"
 	],
 	"scripts": {
 		"install": "pkg-prebuilds-verify ./binding-options.js || node-gyp rebuild",


### PR DESCRIPTION
This (should) allow(s) consumers to recompile the otherwise precompiled binaries on incompatible platforms.



Btw. the source for 2.3.1 is missing from GitHub. There are only some binaries released to NPM.